### PR TITLE
Replace all scss import into css

### DIFF
--- a/Algorithms/JavaScript/scss_to_css_import/index.js
+++ b/Algorithms/JavaScript/scss_to_css_import/index.js
@@ -1,0 +1,28 @@
+/* eslint-disable prettier/prettier */
+
+
+const path = require('path');
+const globby = require('globby');
+const {writeFileSync,readFileSync} = require('fs');
+
+const dir =  __dirname.replace(/\\/g, '/');
+const findPath = `${dir}/lib/**/!(*.d).{ts,tsx,js,jsx}`
+const files = globby
+  .sync(findPath, { dot: true })
+  .map((x) => path.resolve(x));
+console.log({ files: files.length });
+let changedFileCount = 0;
+const transToCSSCount = 0;
+const filesLen = files.length;
+for (let i = 0; i < filesLen; i += 1) {
+  const file = files[i];
+  const content = readFileSync(file, 'utf-8');
+  if (content.includes('scss')) {
+    const changedValue = content.replace(/scss/g, 'css');
+    changedFileCount += 1;
+    writeFileSync(file, changedValue, 'utf8');
+  }
+}
+console.log(
+  `Replaced ${transToCSSCount} styles with suffix css in ${changedFileCount} files`
+);

--- a/Algorithms/JavaScript/scss_to_css_import/package.json
+++ b/Algorithms/JavaScript/scss_to_css_import/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "scsstocss",
+    "version": "1.0.0",
+    "description": "",
+    "main": "index.js",
+    "scripts": {
+      "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "ISC",
+    "dependencies": {
+      "globby": "^11.0.3"
+    }
+  }
+  


### PR DESCRIPTION
This will replace all the scss imports into css. You'll need this when working with typescript react library. When creating build the tsc compiler will not going to replace those scss import into css. With this one you can this file  in postbuild